### PR TITLE
Fixed typo in auth file

### DIFF
--- a/rareapi/views/auth.py
+++ b/rareapi/views/auth.py
@@ -30,7 +30,7 @@ def login_user(request):
         # If authentication was successful, respond with their token
         if authenticated_user is not None:
             token = Token.objects.get(user=authenticated_user)
-            rare_user = RareUsers.objects.get(user=authenticated_user)
+            rare_user = RareUser.objects.get(user=authenticated_user)
             data = json.dumps({"valid": True, "token": token.key, "user_id": rare_user.id})
             return HttpResponse(data, content_type='application/json')
 


### PR DESCRIPTION
#### Changes Made
1. Fixed typo in `auth.py` file in `views` dir 
    Line 33 should now read `rare_user = RareUser.objects.get(user=authenticated_user)`
​
#### Steps to Review
1. Checkout this branch locally and run the application.
```
git fetch --all
git checkout mp-auth-fix
```
2. View code file.
> Confirm file modifications are present as indicated above.
> Confirm no unused code or extraneous comments exist.